### PR TITLE
Fix removing all update-items from player inventory

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: Burricos
 main: com.gipsyking.Burricos.Burricos
-version: 1.5
+version: 1.6
 description: Allows larger donkey inventories when using a crate item with special lore "Donkey double chest"
 author: gipsyking

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.gipsyking.Burricos</groupId>
   <artifactId>Burricos</artifactId>
   <packaging>jar</packaging>
-  <version>1.5-SNAPSHOT</version>
+  <version>1.6-SNAPSHOT</version>
   <name>Burricos</name>
   <url>https://github.com/gipsy-king/Burricos</url>
    

--- a/src/com/gipsyking/Burricos/Burricos.java
+++ b/src/com/gipsyking/Burricos/Burricos.java
@@ -205,7 +205,7 @@ public class Burricos extends JavaPlugin implements Listener{
 		if (chestItem.getAmount() > 1) {
 			chestItem.setAmount(chestItem.getAmount() - 1);
 		} else {
-			event.getPlayer().getInventory().remove(chestItem);
+			event.getPlayer().getInventory().clear(event.getPlayer().getInventory().getHeldItemSlot());
 		}
 		event.getPlayer().updateInventory();
 		


### PR DESCRIPTION
When a player clicks a donkey with a stack of one update-item, he will
not lose all update-item stacks in his inventory anymore.

closes #8 thanks to rourke750!