### PR TITLE
add manual spigot dep needed for civcraft jenkins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,12 @@
       <version>1.8.7-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.spigotmc</groupId>
+      <artifactId>Spigot1.8.7</artifactId>
+      <version>1.8.7</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   
   <repositories>


### PR DESCRIPTION
@rourke750 FYI I can build (`mvn install`) Burricos locally without setting up any special spigot.jars manually - just the result from the spigot buildtool that gets placed in the local maven repository. I get errors marked only in eclipse for the classes that import older nms packages, but no errors on compilation.

Granted I haven't touched your jenkins and I generally don't know much about maven, but this is an issue worth looking into if we want devs to get rolling with hacking on existing plugins fast. Not being able to build locally without undocumented voodoo is a deterrant.